### PR TITLE
Add support for Centos Based image

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,9 @@ RUN set -x \
 
 When using Alpine, it's probably also worth checking out [`su-exec`](https://github.com/ncopa/su-exec) (`apk add --no-cache su-exec`), which since version 0.2 is fully `gosu`-compatible in a fraction of the file size.
 
-### `FROM Centos`
+### `FROM centos`
 
 ```dockerfile
-## GOSU install
 ENV GOSU_VERSION 1.10
 RUN set -x \
     && yum -y install epel-release \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We assume installation inside Docker (probably not the right tool for most use-c
 ### `FROM debian`
 
 ```dockerfile
-ENV GOSU_VERSION 1.9
+ENV GOSU_VERSION 1.10
 RUN set -x \
 	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
 	&& dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
@@ -43,7 +43,7 @@ RUN set -x \
 ### `FROM alpine` (3.3+)
 
 ```dockerfile
-ENV GOSU_VERSION 1.9
+ENV GOSU_VERSION 1.10
 RUN set -x \
 	&& apk add --no-cache --virtual .gosu-deps \
 		dpkg \

--- a/README.md
+++ b/README.md
@@ -63,6 +63,28 @@ RUN set -x \
 
 When using Alpine, it's probably also worth checking out [`su-exec`](https://github.com/ncopa/su-exec) (`apk add --no-cache su-exec`), which since version 0.2 is fully `gosu`-compatible in a fraction of the file size.
 
+### `FROM Centos`
+
+```dockerfile
+## GOSU install
+ENV GOSU_VERSION 1.10
+RUN set -x \
+    && yum -y install epel-release \
+    && yum -y install wget dpkg \
+    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+    && wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
+    && wget -O /tmp/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && gpg --batch --verify /tmp/gosu.asc /usr/bin/gosu \
+    && rm -r "$GNUPGHOME" /tmp/gosu.asc \
+    && chmod +x /usr/bin/gosu \
+    && gosu nobody true \
+    && yum -y remove wget dpkg \
+    && yum clean all
+```
+
+
 ## Why?
 
 ```console


### PR DESCRIPTION
Hi There,

i updated the readme file with the `RUN` instructions to install `gosu` on centos based images for docker.

I took the liberty of also update the version for `1.10`.

Hope it helps.