### PR TITLE
support multiarch host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7-alpine
+FROM golang:1.9-alpine
 
 RUN apk add --no-cache ca-certificates file openssl
 
@@ -22,15 +22,10 @@ WORKDIR /go/src/github.com/tianon/gosu
 # gosu-$(dpkg --print-architecture)
 RUN set -x \
 	&& eval "GOARCH=amd64 go build $BUILD_FLAGS -o /go/bin/gosu-amd64" \
-	&& file /go/bin/gosu-amd64 \
-	&& { /go/bin/gosu-amd64 || true; } \
-	&& /go/bin/gosu-amd64 nobody id \
-	&& /go/bin/gosu-amd64 nobody ls -l /proc/self/fd
+	&& file /go/bin/gosu-amd64
 RUN set -x \
 	&& eval "GOARCH=386 go build $BUILD_FLAGS -o /go/bin/gosu-i386" \
-	&& file /go/bin/gosu-i386 \
-	&& /go/bin/gosu-i386 nobody id \
-	&& /go/bin/gosu-i386 nobody ls -l /proc/self/fd
+	&& file /go/bin/gosu-i386
 RUN set -x \
 	&& eval "GOARCH=arm GOARM=5 go build $BUILD_FLAGS -o /go/bin/gosu-armel" \
 	&& file /go/bin/gosu-armel

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,15 @@ ENV BUILD_FLAGS="-v -ldflags '-d -s -w'"
 COPY *.go /go/src/github.com/tianon/gosu/
 WORKDIR /go/src/github.com/tianon/gosu
 
+# run once with host arch to make sure the binaries work
+RUN set -x \
+	&& eval "go build $BUILD_FLAGS -o /go/bin/gosu-test" \
+	&& file /go/bin/gosu-test \
+	&& { /go/bin/gosu-test || true; } \
+	&& /go/bin/gosu-test nobody id \
+	&& /go/bin/gosu-test nobody ls -l /proc/self/fd \
+	&& rm /go/bin/gosu-test
+
 # gosu-$(dpkg --print-architecture)
 RUN set -x \
 	&& eval "GOARCH=amd64 go build $BUILD_FLAGS -o /go/bin/gosu-amd64" \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.6
 
 # add "nobody" to ALL groups (makes testing edge cases more interesting)
 RUN cut -d: -f1 /etc/group | xargs -n1 addgroup nobody


### PR DESCRIPTION
Dockery added [manifest lists](https://docs.docker.com/registry/spec/manifest-v2-2/ ) so the same image name can be used for more architectures. So the dockers file shouldn't try to execute the x86 version