### PR TITLE
Add build support for mips64le

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,5 +53,8 @@ RUN set -eux; \
 RUN set -eux; \
 	eval "GOARCH=s390x go build $BUILD_FLAGS -o /go/bin/gosu-s390x"; \
 	file /go/bin/gosu-s390x
+RUN set -eux; \
+	eval "GOARCH=mips64le go build $BUILD_FLAGS -o /go/bin/gosu-mips64le"; \
+	file /go/bin/gosu-mips64le
 
 RUN file /go/bin/gosu-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN set -eux; \
 	eval "GOARCH=s390x go build $BUILD_FLAGS -o /go/bin/gosu-s390x"; \
 	file /go/bin/gosu-s390x
 RUN set -eux; \
-	eval "GOARCH=mips64le go build $BUILD_FLAGS -o /go/bin/gosu-mips64le"; \
-	file /go/bin/gosu-mips64le
+	eval "GOARCH=mips64le go build $BUILD_FLAGS -o /go/bin/gosu-mips64el"; \
+	file /go/bin/gosu-mips64el
 
 RUN file /go/bin/gosu-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ RUN set -eux; \
 	eval "GOARCH=arm64 go build $BUILD_FLAGS -o /go/bin/gosu-arm64"; \
 	file /go/bin/gosu-arm64
 RUN set -eux; \
+	eval "GOARCH=mips64le go build $BUILD_FLAGS -o /go/bin/gosu-mips64el"; \
+	file /go/bin/gosu-mips64el
+RUN set -eux; \
 	eval "GOARCH=ppc64 go build $BUILD_FLAGS -o /go/bin/gosu-ppc64"; \
 	file /go/bin/gosu-ppc64
 RUN set -eux; \
@@ -53,8 +56,5 @@ RUN set -eux; \
 RUN set -eux; \
 	eval "GOARCH=s390x go build $BUILD_FLAGS -o /go/bin/gosu-s390x"; \
 	file /go/bin/gosu-s390x
-RUN set -eux; \
-	eval "GOARCH=mips64le go build $BUILD_FLAGS -o /go/bin/gosu-mips64el"; \
-	file /go/bin/gosu-mips64el
 
 RUN file /go/bin/gosu-*


### PR DESCRIPTION
The CI build and test all passed. Related logs below:

<details>
<pre>
Step 17/18 : RUN set -eux; 	eval "GOARCH=mips64le go build $BUILD_FLAGS -o /go/bin/gosu-mips64le"; 	file /go/bin/gosu-mips64le 
 ---> Running in 8cbbb1faf857 
+ eval 'GOARCH=mips64le go build -v -ldflags '"'"'-d -s -w'"'"' -o /go/bin/gosu-mips64le'
+ GOARCH=mips64le go build -v -ldflags '-d -s -w' -o /go/bin/gosu-mips64le 
internal/cpu 
runtime/internal/atomic
internal/bytealg
runtime/internal/sys
internal/race
runtime/internal/math
sync/atomic
runtime
unicode
unicode/utf8
math/bits
math
internal/testlog
internal/reflectlite
sync
errors
sort
io
strconv
bytes
internal/oserror
reflect
syscall
time
internal/fmtsort
internal/syscall/unix
internal/poll
bufio
os
encoding/binary
strings
fmt
github.com/opencontainers/runc/vendor/golang.org/x/sys/unix
os/user
path/filepath
io/ioutil
context
os/exec
log
github.com/opencontainers/runc/libcontainer/user
net/url
github.com/opencontainers/runc/libcontainer/system
text/template/parse
text/template
github.com/tianon/gosu
+ file /go/bin/gosu-mips64le
/go/bin/gosu-mips64le: ELF 64-bit LSB executable, MIPS, MIPS-III version 1 (SYSV), statically linked, Go BuildID=PCP0I6kArfY7twAXF5KJ/UWD8pRH-rFMCrOMjMq5x/5471ssji3e_7Fg6xuL_g/yq6_iByPT9NUIVFtDiEs, stripped
Removing intermediate container 8cbbb1faf857
 ---> 3044274b5f97
Step 18/18 : RUN file /go/bin/gosu-*
 ---> Running in 121505a2c2fe
/go/bin/gosu-amd64:    ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=F-lGSAxnibL3puMHXEHr/rSWB8qh__f9y11DTottt/WS9qLR-aSZO9HDx1Evnf/CqZIs1ctRPY4WQUXT5E3, stripped
/go/bin/gosu-arm64:    ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=2pbs2wg67RaRQ1fnvkJ5/LV_tpYPDnoO5ySXYyhxD/O5iVG4yzBBM9rrZWGGGi/02u7bdLuzkB3-EZiblc8, stripped
/go/bin/gosu-armel:    ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=SZGBpqgYmSoYeMCT1UKN/ZbZ3phF2oEIXRnhYrU7Q/cgJI0gUvrNauzLPUiD-n/BCmUTuiI01Q449sE9Kxx, stripped
/go/bin/gosu-armhf:    ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=0OxquBpSQgH1Q5Wo9nYK/I0t6jxVo9nriFZimXXZ8/cgJI0gUvrNauzLPUiD-n/6eA-8R5__y8Oo-qoECt_, stripped
/go/bin/gosu-i386:     ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, Go BuildID=Zvbr4ceUGpSiBNKfQZnN/tgIsBua9jPUzAPckFGR7/FFYNSu3Hb_7Xo_SHlQy3/XAhSE6i-M86kMYvvfeUO, stripped
/go/bin/gosu-mips64le: ELF 64-bit LSB executable, MIPS, MIPS-III version 1 (SYSV), statically linked, Go BuildID=PCP0I6kArfY7twAXF5KJ/UWD8pRH-rFMCrOMjMq5x/5471ssji3e_7Fg6xuL_g/yq6_iByPT9NUIVFtDiEs, stripped
/go/bin/gosu-ppc64:    ELF 64-bit MSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, Go BuildID=XT12jbW5CC5yF6Tk0vcp/Biym5pAR8jsxIM2K2cW1/9BProHtIlQ9yEu1JywOL/VfYdHDT8OzbrhsAAnFJS, stripped
/go/bin/gosu-ppc64el:  ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, Go BuildID=FDNKcwpSlKlMEIYXPrK8/FlKsVkjH09dl51aVkaym/ZYdWndZO5trqgp5e4GhH/-c-WFO7jaXuvxlUU4LVt, stripped
/go/bin/gosu-s390x:    ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), statically linked, Go BuildID=t2Kf4BKTaWnfwlW3mG9M/8kWrWgVdCImnlbkWJU89/WFS7Jk1LVqvp47ZKQgVu/VPzAMFLdeCvJGGwsmwO0, stripped
Removing intermediate container 121505a2c2fe
 ---> 6c8161105d93
Successfully built 6c8161105d93
Successfully tagged gosu:latest
+rm -f 'gosu*' 'SHA256SUMS*'
+tar -xv
+docker run --rm gosu sh -c 'cd /go/bin && tar -c gosu*'
gosu-amd64
gosu-arm64
gosu-armel
gosu-armhf
gosu-i386
gosu-mips64le
gosu-ppc64
gosu-ppc64el
gosu-s390x
+tee SHA256SUMS
+sha256sum gosu-amd64 gosu-arm64 gosu-armel gosu-armhf gosu-i386 gosu-mips64le gosu-ppc64 gosu-ppc64el gosu-s390x
5ae8343f27d9882f3122a34502f15b915f273a51746ede39f26511b90476f79c  gosu-amd64
b471a3f7d01e02dc3ac063f6765933cfe8d5f444649a60602b70c430284edf3f  gosu-arm64
96d00c4ec79a2a3e6f46e52055121d7e1dba409ffb1b4e91ef5c9bd35a734516  gosu-armel
480eb6180daffee19e2a49d113bffd08bf4c534ab5ad83bb4d4532a5dd763267  gosu-armhf
4e038382cae9419402c32191d695152a131af21fb76d6a4e8e015b585053bcf0  gosu-i386
6df6361e52aa5c34e57341469caaad056e53141639feeb03e4b3898bbbce7fc7  gosu-mips64le
a7a8436b1370957bf9dbdb7ad90cde46c852271bfa52cb0f3133a757518ab1c8  gosu-ppc64
6219bdf5d4f081b6b94e6fd2762422031fe6202f79fd0ff5434a0cf704bd0e96  gosu-ppc64el
b8272c86e64a4565723fc439995d3d46cca6943dd20d389b0bf228ca4081e943  gosu-s390x
+file gosu-amd64 gosu-arm64 gosu-armel gosu-armhf gosu-i386 gosu-mips64le gosu-ppc64 gosu-ppc64el gosu-s390x
gosu-amd64:    ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
gosu-arm64:    ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
gosu-armel:    ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, stripped
gosu-armhf:    ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, stripped
gosu-i386:     ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, stripped
gosu-mips64le: ELF 64-bit LSB executable, MIPS, MIPS-III version 1 (SYSV), statically linked, stripped
gosu-ppc64:    ELF 64-bit MSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, stripped
gosu-ppc64el:  ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, stripped
gosu-s390x:    ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), statically linked, stripped
+ls -lFh gosu-amd64 gosu-arm64 gosu-armel gosu-armhf gosu-i386 gosu-mips64le gosu-ppc64 gosu-ppc64el gosu-s390x SHA256SUMS
-rwxr-xr-x 1 travis travis 2.3M Mar 13 03:30 gosu-amd64*
-rwxr-xr-x 1 travis travis 2.4M Mar 13 03:30 gosu-arm64*
-rwxr-xr-x 1 travis travis 2.2M Mar 13 03:30 gosu-armel*
-rwxr-xr-x 1 travis travis 2.1M Mar 13 03:30 gosu-armhf*
-rwxr-xr-x 1 travis travis 2.0M Mar 13 03:30 gosu-i386*
-rwxr-xr-x 1 travis travis 2.5M Mar 13 03:30 gosu-mips64le*
-rwxr-xr-x 1 travis travis 2.4M Mar 13 03:30 gosu-ppc64*
-rwxr-xr-x 1 travis travis 2.4M Mar 13 03:30 gosu-ppc64el*
-rwxr-xr-x 1 travis travis 2.5M Mar 13 03:30 gosu-s390x*
-rw-rw-r-- 1 travis travis  697 Mar 13 03:30 SHA256SUMS
++dpkg --print-architecture
+./gosu-amd64 --help
Usage: gosu-amd64 user-spec command [args]
   eg: gosu-amd64 tianon bash
       gosu-amd64 nobody:root bash -c 'whoami && id'
       gosu-amd64 1000:1 id 
gosu-amd64 version: 1.11 (go1.13.8 on linux/amd64; gc) 
gosu-amd64 license: GPL-3 (full text at https://github.com/tianon/gosu) 
The command "./build.sh" exited with 0. 
</pre>
</details>