### PR TITLE
Add upx to Docker build to compress compat bins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.13-alpine3.10
 
-RUN apk add --no-cache file
+RUN apk add --no-cache file upx
 
 ENV RUNC_VERSION v1.0.0-rc9
 
@@ -22,34 +22,41 @@ WORKDIR /go/src/github.com/tianon/gosu
 RUN set -eux; \
 	eval "GOARCH=amd64 go build $BUILD_FLAGS -o /go/bin/gosu-amd64"; \
 	file /go/bin/gosu-amd64; \
+	upx /go/bin/gosu-amd64; \
 	/go/bin/gosu-amd64 --version; \
 	/go/bin/gosu-amd64 nobody id; \
 	/go/bin/gosu-amd64 nobody ls -l /proc/self/fd
 RUN set -eux; \
 	eval "GOARCH=386 go build $BUILD_FLAGS -o /go/bin/gosu-i386"; \
 	file /go/bin/gosu-i386; \
+	upx /go/bin/gosu-i386; \
 	/go/bin/gosu-i386 --version; \
 	/go/bin/gosu-i386 nobody id; \
 	/go/bin/gosu-i386 nobody ls -l /proc/self/fd
 RUN set -eux; \
 	eval "GOARCH=arm GOARM=5 go build $BUILD_FLAGS -o /go/bin/gosu-armel"; \
-	file /go/bin/gosu-armel
+	file /go/bin/gosu-armel; \
+	upx /go/bin/gosu-armel
 RUN set -eux; \
 	eval "GOARCH=arm GOARM=6 go build $BUILD_FLAGS -o /go/bin/gosu-armhf"; \
-	file /go/bin/gosu-armhf
+	file /go/bin/gosu-armhf; \
+	upx /go/bin/gosu-armhf
 # boo Raspberry Pi, making life hard
 #RUN set -eux; \
 #	eval "GOARCH=arm GOARM=7 go build $BUILD_FLAGS -o /go/bin/gosu-armhf"; \
 #	file /go/bin/gosu-armhf
 RUN set -eux; \
 	eval "GOARCH=arm64 go build $BUILD_FLAGS -o /go/bin/gosu-arm64"; \
-	file /go/bin/gosu-arm64
+	file /go/bin/gosu-arm64; \
+	upx /go/bin/gosu-arm64
 RUN set -eux; \
 	eval "GOARCH=ppc64 go build $BUILD_FLAGS -o /go/bin/gosu-ppc64"; \
-	file /go/bin/gosu-ppc64
+	file /go/bin/gosu-ppc64; \
+	upx /go/bin/gosu-ppc64
 RUN set -eux; \
 	eval "GOARCH=ppc64le go build $BUILD_FLAGS -o /go/bin/gosu-ppc64el"; \
-	file /go/bin/gosu-ppc64el
+	file /go/bin/gosu-ppc64el; \
+	upx /go/bin/gosu-ppc64el
 RUN set -eux; \
 	eval "GOARCH=s390x go build $BUILD_FLAGS -o /go/bin/gosu-s390x"; \
 	file /go/bin/gosu-s390x

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ RUN set -eux; \
 Older Debian releases (or newer `gosu` releases):
 
 ```dockerfile
-ENV GOSU_VERSION 1.11
+ENV GOSU_VERSION 1.12
 RUN set -eux; \
 # save list of currently installed packages for later so we can clean up
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -59,7 +59,7 @@ RUN set -eux; \
 **Note:** when using Alpine, it's probably also worth checking out [`su-exec`](https://github.com/ncopa/su-exec) (`apk add --no-cache su-exec`) instead, which since version 0.2 is fully `gosu`-compatible in a fraction of the file size.
 
 ```dockerfile
-ENV GOSU_VERSION 1.11
+ENV GOSU_VERSION 1.12
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .gosu-deps \

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "1.11"
+const Version = "1.12"


### PR DESCRIPTION
The Ultimate Packer for eXecutables (upx) is a really good way to compress binaries...
```
        File size         Ratio      Format      Name
   --------------------   ------   -----------   -----------
   2404352 ->    916880   38.13%   linux/amd64   gosu-amd64
   2490368 ->    861176   34.58%   linux/arm64   gosu-arm64
   2228224 ->    869936   39.04%    linux/arm    gosu-armel
   2162688 ->    862008   39.86%    linux/arm    gosu-armhf
   2084864 ->    872784   41.86%   linux/i386    gosu-i386
   2424832 ->    887088   36.58%   linux/ppc64   gosu-ppc64
   2424832 ->    879236   36.26%  linux/ppc64le  gosu-ppc64el
upx: gosu-s390x: UnknownExecutableFormatException
   --------------------   ------   -----------   -----------
  16220160 ->   6149108   37.91%                 [ 7 files ]
```
The s390x format is unsupported currently.

Bump version to 1.12 because of changes to binaries