### PR TITLE
Add Debian-based copy of the test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ script:
   - ./build.sh
   - ./test.sh gosu-amd64
   - ./test.sh gosu-i386
+  - ./test.sh --debian gosu-amd64
+  - ./test.sh --debian gosu-i386

--- a/Dockerfile.test-alpine
+++ b/Dockerfile.test-alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.11
 
 # add "nobody" to ALL groups (makes testing edge cases more interesting)
 RUN cut -d: -f1 /etc/group | xargs -n1 addgroup nobody

--- a/Dockerfile.test-debian
+++ b/Dockerfile.test-debian
@@ -1,0 +1,75 @@
+FROM debian:buster-slim
+
+# add "nobody" to ALL groups (makes testing edge cases more interesting)
+RUN cut -d: -f1 /etc/group | xargs -n1 -I'{}' usermod -aG '{}' nobody
+# emulate Alpine's "games" user (which is part of the "users" group)
+RUN usermod -aG users games
+
+RUN { \
+		echo '#!/bin/sh'; \
+		echo 'set -ex'; \
+		echo; \
+		echo 'spec="$1"; shift'; \
+		echo; \
+		echo 'expec="$1"; shift'; \
+		echo 'real="$(gosu "$spec" id -u):$(gosu "$spec" id -g):$(gosu "$spec" id -G)"'; \
+		echo '[ "$expec" = "$real" ]'; \
+		echo; \
+		echo 'expec="$1"; shift'; \
+		# have to "|| true" this one because of "id: unknown ID 1000" (rightfully) having a nonzero exit code
+		echo 'real="$(gosu "$spec" id -un):$(gosu "$spec" id -gn):$(gosu "$spec" id -Gn)" || true'; \
+		echo '[ "$expec" = "$real" ]'; \
+	} > /usr/local/bin/gosu-t \
+	&& chmod +x /usr/local/bin/gosu-t
+
+COPY gosu /usr/local/bin/
+
+# adjust users so we can make sure the tests are interesting
+RUN chgrp nogroup /usr/local/bin/gosu \
+	&& chmod +s /usr/local/bin/gosu
+USER nobody
+ENV HOME /omg/really/gosu/nowhere
+# now we should be nobody, ALL groups, and have a bogus useless HOME value
+
+RUN id
+
+RUN gosu-t 0 "0:0:$(id -G root)" "root:root:$(id -Gn root)"
+RUN gosu-t 0:0 '0:0:0' 'root:root:root'
+RUN gosu-t root "0:0:$(id -G root)" "root:root:$(id -Gn root)"
+RUN gosu-t 0:root '0:0:0' 'root:root:root'
+RUN gosu-t root:0 '0:0:0' 'root:root:root'
+RUN gosu-t root:root '0:0:0' 'root:root:root'
+RUN gosu-t 1000 "1000:$(id -g):$(id -g)" "1000:$(id -gn):$(id -gn)"
+RUN gosu-t 0:1000 '0:1000:1000' 'root:1000:1000'
+RUN gosu-t 1000:1000 '1000:1000:1000' '1000:1000:1000'
+RUN gosu-t root:1000 '0:1000:1000' 'root:1000:1000'
+RUN gosu-t 1000:root '1000:0:0' '1000:root:root'
+RUN gosu-t 1000:daemon "1000:$(id -g daemon):$(id -g daemon)" '1000:daemon:daemon'
+RUN gosu-t games "$(id -u games):$(id -g games):$(id -G games)" 'games:games:games users'
+RUN gosu-t games:daemon "$(id -u games):$(id -g daemon):$(id -g daemon)" 'games:daemon:daemon'
+
+RUN gosu-t 0: "0:0:$(id -G root)" "root:root:$(id -Gn root)"
+RUN gosu-t '' "$(id -u):$(id -g):$(id -G)" "$(id -un):$(id -gn):$(id -Gn)"
+RUN gosu-t ':0' "$(id -u):0:0" "$(id -un):root:root"
+
+RUN [ "$(gosu 0 env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(gosu 0:0 env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(gosu root env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(gosu 0:root env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(gosu root:0 env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(gosu root:root env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(gosu 0:1000 env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(gosu root:1000 env | grep '^HOME=')" = 'HOME=/root' ]
+RUN [ "$(gosu 1000 env | grep '^HOME=')" = 'HOME=/' ]
+RUN [ "$(gosu 1000:0 env | grep '^HOME=')" = 'HOME=/' ]
+RUN [ "$(gosu 1000:root env | grep '^HOME=')" = 'HOME=/' ]
+RUN [ "$(gosu games env | grep '^HOME=')" = 'HOME=/usr/games' ]
+RUN [ "$(gosu games:daemon env | grep '^HOME=')" = 'HOME=/usr/games' ]
+
+# make sure we error out properly in unexpected cases like an invalid username
+RUN ! gosu bogus true
+RUN ! gosu 0day true
+RUN ! gosu 0:bogus true
+RUN ! gosu 0:0day true
+
+# something missing?  some other functionality we could test easily?  PR! :D


### PR DESCRIPTION
This is useful for testing architectures like mips64le, which aren't supported in Alpine (yet?), as in https://github.com/tianon/gosu/pull/69. :+1: :metal: