### PR TITLE
fix CWE-703

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	}
 
 	// clear HOME so that SetupUser will set it
-	os.Unsetenv("HOME")
+	defer os.Unsetenv("HOME")
 
 	if err := SetupUser(os.Args[1]); err != nil {
 		log.Fatalf("error: failed switching to %q: %v", os.Args[1], err)


### PR DESCRIPTION
fix the following gosec warn:
```
  G104 (CWE-703): Errors unhandled. (Confidence: HIGH, Severity: LOW)
```