### PR TITLE
Disallow installing gosu with setuid

### DIFF
--- a/Dockerfile.test-alpine
+++ b/Dockerfile.test-alpine
@@ -25,6 +25,7 @@ COPY gosu /usr/local/bin/
 # adjust users so we can make sure the tests are interesting
 RUN chgrp nobody /usr/local/bin/gosu \
 	&& chmod +s /usr/local/bin/gosu
+ENV GOSU_PLEASE_LET_ME_BE_COMPLETELY_INSECURE_I_GET_TO_KEEP_ALL_THE_PIECES="I've seen things you people wouldn't believe. Attack ships on fire off the shoulder of Orion. I watched C-beams glitter in the dark near the Tannhäuser Gate. All those moments will be lost in time, like tears in rain. Time to die."
 USER nobody
 ENV HOME /omg/really/gosu/nowhere
 # now we should be nobody, ALL groups, and have a bogus useless HOME value

--- a/Dockerfile.test-debian
+++ b/Dockerfile.test-debian
@@ -27,6 +27,7 @@ COPY gosu /usr/local/bin/
 # adjust users so we can make sure the tests are interesting
 RUN chgrp nogroup /usr/local/bin/gosu \
 	&& chmod +s /usr/local/bin/gosu
+ENV GOSU_PLEASE_LET_ME_BE_COMPLETELY_INSECURE_I_GET_TO_KEEP_ALL_THE_PIECES="I've seen things you people wouldn't believe. Attack ships on fire off the shoulder of Orion. I watched C-beams glitter in the dark near the Tannhäuser Gate. All those moments will be lost in time, like tears in rain. Time to die."
 USER nobody
 ENV HOME /omg/really/gosu/nowhere
 # now we should be nobody, ALL groups, and have a bogus useless HOME value

--- a/main.go
+++ b/main.go
@@ -47,6 +47,15 @@ Usage: {{ .Self }} user-spec command [args]
 func main() {
 	log.SetFlags(0) // no timestamps on our logs
 
+	if ok := os.Getenv("GOSU_PLEASE_LET_ME_BE_COMPLETELY_INSECURE_I_GET_TO_KEEP_ALL_THE_PIECES"); ok != "I've seen things you people wouldn't believe. Attack ships on fire off the shoulder of Orion. I watched C-beams glitter in the dark near the Tannhäuser Gate. All those moments will be lost in time, like tears in rain. Time to die." {
+		if fi, err := os.Stat("/proc/self/exe"); err != nil {
+			log.Fatalf("error: %v", err)
+		} else if fi.Mode()&os.ModeSetuid != 0 {
+			// ... oh no
+			log.Fatalf("error: %q appears to be installed with the 'setuid' bit set, which is an *extremely* insecure and completely unsupported configuration! (what you want instead is likely 'sudo' or 'su')", os.Args[0])
+		}
+	}
+
 	if len(os.Args) >= 2 {
 		switch os.Args[1] {
 		case "--help", "-h", "-?":


### PR DESCRIPTION
There are workarounds for this, but I will intentionally not be describing them because this is definitely not something I can endorse in any way.  Please don't use gosu in this way.

(This has come up enough times recently that I want to take a stronger stance on it and explicitly disavow/disallow it.)