### PR TITLE
Add new "govulncheck-with-excludes.sh" wrapper script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
       - run: go install golang.org/x/vuln/cmd/govulncheck@v0.1.0
       # (update "go-version" above when updating this version; https://github.com/golang/vuln/blob/v0.1.0/go.mod#L3)
 
-      - run: for gosu in gosu-*; do govulncheck -mode=binary "$gosu"; done
+      - run: for gosu in gosu-*; do ./govulncheck-with-excludes.sh -mode=binary "$gosu"; done

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,11 @@
 
 This project does not rebuild/release to "fix" CVEs which do not apply to actual builds of `gosu`.  For example, this includes any CVE in Go which applies to interfaces that `gosu` does not ever invoke, such as `net/http`, `archive/tar`, `encoding/xml`, etc.
 
-Before reporting that `gosu` is "vulnerable" to a particular CVE, please run [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) to determine whether the latest release is *actually* using the vulnerable functionality.  See [this excellent blog post](https://go.dev/blog/vuln) from the Go team for more information about the `govulncheck` tool and the methodology by which it is maintained.
+Before reporting that `gosu` is "vulnerable" to a particular CVE, please run our [`./govulncheck-with-excludes.sh`](govulncheck-with-excludes.sh) wrapper around [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) to determine whether the latest release is *actually* using the vulnerable functionality.  See [this excellent blog post](https://go.dev/blog/vuln) from the Go team for more information about the `govulncheck` tool and the methodology by which it is maintained.
 
 If you have a tool which is reporting that `gosu` is vulnerable to a particular CVE but `govulncheck` does not agree, **please** report this as a false positive to your CVE scanning vendor so that they can improve their tooling.  (If you wish to verify that your reported CVE is part of `govulncheck`'s dataset and thus covered by their tool, you can check [the vulndb repository](https://github.com/golang/vulndb) where they track those.)
+
+Our wrapper script ([`govulncheck-with-excludes.sh`](govulncheck-with-excludes.sh)) includes a very small set of vulnerabilities that will be reported by `govulncheck` which do not apply (due to other mitigations or otherwise).
 
 # Reporting Vulnerabilities
 

--- a/govulncheck-with-excludes.sh
+++ b/govulncheck-with-excludes.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# a wrapper / replacement for "govulncheck" which allows for excluding vulnerabilities
+# (https://github.com/golang/go/issues/59507)
+
+excludeVulns="$(jq -nc '[
+
+	# https://pkg.go.dev/vuln/GO-2023-1840
+	# we already mitigate setuid in our code
+	"GO-2023-1840", "CVE-2023-29403",
+	# (https://github.com/tianon/gosu/issues/128#issuecomment-1607803883)
+
+	empty # trailing comma hack (makes diffs smaller)
+]')"
+export excludeVulns
+
+if ! command -v govulncheck > /dev/null; then
+	govulncheck() {
+		local user; user="$(id -u):$(id -g)"
+		local args=(
+			--rm --interactive --init
+			--user "$user"
+			--env HOME=/tmp
+			--env GOPATH=/tmp/go
+			--volume govulncheck:/tmp
+			--env CGO_ENABLED=0
+			--mount "type=bind,src=$PWD,dst=/wd,ro"
+			--workdir /wd
+			"${GOLANG_IMAGE:-golang:latest}"
+			sh -euc '
+				go install golang.org/x/vuln/cmd/govulncheck@latest > /dev/null
+				exec "$GOPATH/bin/govulncheck" "$@"
+			' --
+		)
+		docker run "${args[@]}" "$@"
+	}
+fi
+
+if out="$(govulncheck "$@")"; then
+	printf '%s\n' "$out"
+	exit 0
+fi
+
+json="$(govulncheck -json "$@")"
+
+vulns="$(jq <<<"$json" -cs 'map(select(has("vulnerability")) | .vulnerability.osv)')"
+if [ "$(jq <<<"$vulns" -r 'length')" -le 0 ]; then
+	printf '%s\n' "$out"
+	exit 1
+fi
+
+filtered="$(jq <<<"$vulns" -c '
+	(env.excludeVulns | fromjson) as $exclude
+	| map(select(
+		.id as $id
+		| $exclude | index($id) | not
+	))
+')"
+
+text="$(jq <<<"$filtered" -r 'map("- \(.id) (aka \(.aliases | join(", ")))\n\n\t\(.details | gsub("\n"; "\n\t"))") | join("\n\n")')"
+
+if [ -z "$text" ]; then
+	printf 'No vulnerabilities found.\n'
+	exit 0
+else
+	printf '%s\n' "$text"
+	exit 1
+fi

--- a/main.go
+++ b/main.go
@@ -53,6 +53,9 @@ func main() {
 		} else if fi.Mode()&os.ModeSetuid != 0 {
 			// ... oh no
 			log.Fatalf("error: %q appears to be installed with the 'setuid' bit set, which is an *extremely* insecure and completely unsupported configuration! (what you want instead is likely 'sudo' or 'su')", os.Args[0])
+		} else if fi.Mode()&os.ModeSetgid != 0 {
+			// ... oh no
+			log.Fatalf("error: %q appears to be installed with the 'setgid' bit set, which is not quite *as* insecure as 'setuid', but still not great, and definitely a completely unsupported configuration! (what you want instead is likely 'sudo' or 'su')", os.Args[0])
 		}
 	}
 


### PR DESCRIPTION
This allows us to exclude GO-2023-1840 (aka CVE-2023-29403; https://github.com/tianon/gosu/issues/128#issuecomment-1607803883) from our report since we already refuse to operate when users have enabled the `setuid` bit on the binary.

Additionally, this updates our in-code check for `setuid` to also disallow `setgid`, but the impact of that configuration is lesser (so this is considered a best-effort pre-emptive mitigation -- hopefully the block on `setuid` has already discouraged users from using `gosu` in this way).

(This is essentially a workaround for https://github.com/golang/go/issues/59507, which isn't ideal, but it's the best we have for now.)