### PR TITLE
Update to Go 1.20.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,12 @@
-FROM golang:1.18.2-bullseye
+FROM golang:1.20.5-bookworm
 
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		arch-test \
 		file \
-		patch \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-# https://github.com/golang/go/issues/56426
-RUN set -eux; \
-	wget -O /tmp/go-mips.patch 'https://github.com/golang/go/commit/2c7c98c3ad719aa9d6d2594827a6894ff9950042.patch'; \
-	patch --strip=1 --directory=/usr/local/go --input=/tmp/go-mips.patch
 
 # note: we cannot add "-s" here because then "govulncheck" does not work (see SECURITY.md); the ~0.2MiB increase (as of 2022-12-16, Go 1.18) is worth it
 ENV BUILD_FLAGS="-v -trimpath -ldflags '-d -w'"

--- a/Dockerfile.test-alpine
+++ b/Dockerfile.test-alpine
@@ -1,7 +1,7 @@
-FROM alpine:3.17
+FROM alpine:3.19
 
 # add "nobody" to ALL groups (makes testing edge cases more interesting)
-RUN cut -d: -f1 /etc/group | xargs -n1 addgroup nobody
+RUN cut -d: -f1 /etc/group | xargs -rtn1 addgroup nobody
 
 RUN { \
 		echo '#!/bin/sh'; \

--- a/Dockerfile.test-debian
+++ b/Dockerfile.test-debian
@@ -1,7 +1,7 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # add "nobody" to ALL groups (makes testing edge cases more interesting)
-RUN cut -d: -f1 /etc/group | xargs -n1 -I'{}' usermod -aG '{}' nobody
+RUN cut -d: -f1 /etc/group | xargs -rtI'{}' usermod -aG '{}' nobody
 # emulate Alpine's "games" user (which is part of the "users" group)
 RUN usermod -aG users games
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,12 @@ If you have a tool which is reporting that `gosu` is vulnerable to a particular 
 
 Our `govulncheck` wrapper script ([`govulncheck-with-excludes.sh`](govulncheck-with-excludes.sh)) may include a small set of vulnerabilities that will be reported by `govulncheck` which do not apply (due to other mitigations or otherwise).  See comments in that script for details.
 
+## Go Version Updates
+
+Similar to the how traditional Linux distributions such as Debian handle rebuilding binaries between stable releases / for updated compilers (or rather, the situations and reasons for which they do *not* do so), and in the same spirit as the above CVE policy, we do *not* update the compiler/rebuild with a newer compiler unless there is a compelling functional or security reason in the code that ends up as part of the `gosu` binary that warrants doing so.
+
+As above, if you have a "security scanning" tool which does not agree with this policy, please take that up with your scanning tool vendor (report as a false positive, improve the tool to `govulncheck`, etc).
+
 # Reporting Vulnerabilities
 
 The surface area of `gosu` itself is really limited -- it only directly contains a small amount of Go code to instrument an interface that is part of [`github.com/moby/sys/user` (the Docker Engine's `--user` parsing code, to be exact)](https://github.com/moby/sys/tree/main/user) (and which itself is a pretty limited interface) intended for providing the same behavior as Docker's `--user` flag (switching from `root` to a less privileged user), but from within an already running container.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,9 @@ If you have a tool which is reporting that `gosu` is vulnerable to a particular 
 
 Our `govulncheck` wrapper script ([`govulncheck-with-excludes.sh`](govulncheck-with-excludes.sh)) may include a small set of vulnerabilities that will be reported by `govulncheck` which do not apply (due to other mitigations or otherwise).  See comments in that script for details.
 
-## Go Version Updates
+## Version Updates
 
-Similar to the how traditional Linux distributions such as Debian handle rebuilding binaries between stable releases / for updated compilers (or rather, the situations and reasons for which they do *not* do so), and in the same spirit as the above CVE policy, we do *not* update the compiler/rebuild with a newer compiler unless there is a compelling functional or security reason in the code that ends up as part of the `gosu` binary that warrants doing so.
+Similar to the how traditional Linux distributions such as Debian handle rebuilding binaries between stable releases / for updated compilers (or rather, the situations and reasons for which they do *not* do so), and in the same spirit as the above CVE policy and [Go's "Minimal Version Selection"](https://research.swtch.com/vgo-mvs), we do *not* update the compiler/rebuild with a newer compiler unless there is a compelling functional or security reason in the code that ends up as part of the `gosu` binary that warrants doing so.
 
 As above, if you have a "security scanning" tool which does not agree with this policy, please take that up with your scanning tool vendor (report as a false positive, improve the tool to `govulncheck`, etc).
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tianon/gosu
 
-go 1.18
+go 1.20
 
 require (
 	github.com/moby/sys/user v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.20
 
 require (
 	github.com/moby/sys/user v0.1.0
-	golang.org/x/sys v0.13.0
+	golang.org/x/sys v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/moby/sys/user v0.1.0 h1:WmZ93f5Ux6het5iituh9x2zAG7NFY9Aqi49jjE1PaQg=
 github.com/moby/sys/user v0.1.0/go.mod h1:fKJhFOnsCN6xZ5gSfbM6zaHGgDJMrqt9/reuj4T7MmU=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/govulncheck-with-excludes.sh
+++ b/govulncheck-with-excludes.sh
@@ -6,9 +6,10 @@ set -Eeuo pipefail
 
 excludeVulns="$(jq -nc '[
 
+	# fixed in Go 1.20.5+
 	# https://pkg.go.dev/vuln/GO-2023-1840
 	# we already mitigate setuid in our code
-	"GO-2023-1840", "CVE-2023-29403",
+	#"GO-2023-1840", "CVE-2023-29403",
 	# (https://github.com/tianon/gosu/issues/128#issuecomment-1607803883)
 
 	empty # trailing comma hack (makes diffs smaller)


### PR DESCRIPTION
This allows us to drop the mips64le upstream patch we've been applying (fixed in Go 1.20.0) and the GO-2023-1840 / CVE-2023-29403 govulncheck exclusion (which still doesn't apply, but was fixed in Go in 1.20.5 and thus we no longer need to ignore).

Also:
- update the tests to Debian Bookworm and Alpine 3.19
- update `SECURITY.md` to make our Go version update policy explicit and written down (including the parallel to how Linux distributions handle similar situations)

(refs #136)