### PR TITLE
Add an "RPM-based" section back to `INSTALL.md`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,6 +82,43 @@ RUN set -eux; \
 	gosu nobody true
 ```
 
+## `FROM centos|oraclelinux|...|ubi|...` (RPM-based distro)
+
+```dockerfile
+ENV GOSU_VERSION 1.17
+RUN set -eux; \
+	\
+	rpmArch="$(rpm --query --queryformat='%{ARCH}' rpm)"; \
+	case "$rpmArch" in \
+		aarch64) dpkgArch='arm64' ;; \
+		armv[67]*) dpkgArch='armhf' ;; \
+		i[3456]86) dpkgArch='i386' ;; \
+		ppc64le) dpkgArch='ppc64el' ;; \
+		riscv64 | s390x) dpkgArch="$rpmArch" ;; \
+		x86_64) dpkgArch='amd64' ;; \
+		*) echo >&2 "error: unknown/unsupported architecture '$rpmArch'"; exit 1 ;; \
+	esac; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu --version; \
+	gosu nobody true
+```
+
+Notes:
+
+- `gosu`'s `armhf` builds are ARMv6 (not ARMv7 as they might be in Debian proper) thanks to Raspbian, hence the `armv6` allowance above
+- `rpm` architecture values sourced from https://rpmfind.net/linux/rpm2html/search.php?query=rpm
+
 ## Others / Lazy Method
 
 ```dockerfile


### PR DESCRIPTION
Thanks to `rpm --query --queryformat='%{ARCH}' rpm`, I feel good about documenting this "officially" again. 🚀

(Special thanks to @grooverdan for inspiring me to look at/consider/research this again :heart:)