### PR TITLE
Update to Go 1.24.6 (esp. for GO-2025-3956)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0-bookworm
+FROM golang:1.24.6-bookworm
 
 RUN set -eux; \
 	apt-get update; \


### PR DESCRIPTION
This is also known as CVE-2025-47906:

> If the PATH environment variable contains paths which are executables (rather than just directories), passing certain strings to LookPath ("", ".", and ".."), can result in the binaries listed in the PATH being unexpectedly returned.

https://pkg.go.dev/vuln/GO-2025-3956

I don't think this is a critical issue with `gosu` (as it requires a misconfigured environment **and** we only invoke `LookPath` _after_ we've dropped from root), but one worth updating for.