### PR TITLE
add loong64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,5 +69,6 @@ RUN ARCH=mips64el GOARCH=mips64le    gosu-build-and-test.sh
 RUN ARCH=ppc64el  GOARCH=ppc64le     gosu-build-and-test.sh
 RUN ARCH=riscv64  GOARCH=riscv64     gosu-build-and-test.sh
 RUN ARCH=s390x    GOARCH=s390x       gosu-build-and-test.sh
+RUN ARCH=loong64  GOARCH=loong64     gosu-build-and-test.sh
 
 RUN set -eux; go version -m /go/bin/gosu-*; ls -lAFh /go/bin/gosu-*; file /go/bin/gosu-*

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -92,7 +92,7 @@ RUN set -eux; \
 		armv[67]*) dpkgArch='armhf' ;; \
 		i[3456]86) dpkgArch='i386' ;; \
 		ppc64le) dpkgArch='ppc64el' ;; \
-		riscv64 | s390x) dpkgArch="$rpmArch" ;; \
+		riscv64 | s390x | loongarch64) dpkgArch="$rpmArch" ;; \
 		x86_64) dpkgArch='amd64' ;; \
 		*) echo >&2 "error: unknown/unsupported architecture '$rpmArch'"; exit 1 ;; \
 	esac; \


### PR DESCRIPTION
LoongArch is a RISC-based CPU architecture increasingly adopted in server, cloud, and edge computing environments. As the LoongArch ecosystem grows, more and more open-source projects and container images provide LoongArch builds—for example, Alpine 3.22 already supports it, and Debian support is coming soon.

  Currently, official Gosu builds do not support LoongArch. This forces LoongArch users to manually build or replace binaries when switching users in containers, increasing complexity and overhead.

Adding support for LoongArch builds would:

1. Make official Gosu binaries directly usable on LoongArch platforms;

2. Simplify user-switching workflows in containers and improve cross-architecture compatibility;

3. Expand Gosu’s usability and value in multi-architecture environments.