### PR TITLE
Upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # used for both building "latest" and for govulncheck in the final step
       - run: docker pull golang

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     name: govulncheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: download
         run: |


### PR DESCRIPTION
Upgrade GitHub actions checkout to silence the warning below

  ```
  Node.js 20 actions are deprecated. The following actions are
  running on Node.js 20 and may not work as expected:
  actions/checkout@v4.
  Actions will be forced to run with Node.js 24 by default
  starting June 16th, 2026. Node.js 20 will be removed from the
  runner on September 16th, 2026. Please check if updated
  versions of these actions are available that support
  Node.js 24. To opt into Node.js 24 now, set the
  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable
  on the runner or in your workflow file.
  Once Node.js 24 becomes the default, you can temporarily opt
  out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
  For more information see:
  https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
  ```